### PR TITLE
Link to GitHub rendered markdown documents instead of raw

### DIFF
--- a/data-submission-api/clients/ewon-flexy/index.html
+++ b/data-submission-api/clients/ewon-flexy/index.html
@@ -164,7 +164,7 @@ SendData:
           <div class="download-card">
             <div class="download-card-title">Package README</div>
             <p class="download-card-desc">Step-by-step setup, optional conditional group logic, and debugging guidance.</p>
-            <a class="btn btn-ghost btn-sm" style="margin-top:0.5rem;" href="../packages/ewon-flexy/README.md">Open README</a>
+            <a class="btn btn-ghost btn-sm" style="margin-top:0.5rem;" href="https://github.com/waterlyapp/waterlyconnect-docs/blob/main/data-submission-api/clients/packages/ewon-flexy/README.md" target="_blank" rel="noopener">Open README</a>
           </div>
           <div class="download-card">
             <div class="download-card-title">Source folder</div>

--- a/data-submission-api/clients/ignition/index.html
+++ b/data-submission-api/clients/ignition/index.html
@@ -160,7 +160,7 @@ waterly.sendDataToWaterly(tags)</code></pre>
           <div class="download-card">
             <div class="download-card-title">Package README</div>
             <p class="download-card-desc">Step-by-step import, credential setup, event configuration, and troubleshooting notes.</p>
-            <a class="btn btn-ghost btn-sm" style="margin-top:0.5rem;" href="../packages/ignition/README.md">Open README</a>
+            <a class="btn btn-ghost btn-sm" style="margin-top:0.5rem;" href="https://github.com/waterlyapp/waterlyconnect-docs/blob/main/data-submission-api/clients/packages/ignition/README.md" target="_blank" rel="noopener">Open README</a>
           </div>
           <div class="download-card">
             <div class="download-card-title">Source folder</div>

--- a/data-submission-api/clients/nodejs/index.html
+++ b/data-submission-api/clients/nodejs/index.html
@@ -131,7 +131,7 @@ await client.submitData(tags);</code></pre>
           <div class="download-card">
             <div class="download-card-title">Package README</div>
             <p class="download-card-desc">Full API reference, type documentation, and usage notes.</p>
-            <a class="btn btn-ghost btn-sm" style="margin-top:0.5rem;" href="../packages/nodejs-client/README.md">Open README</a>
+            <a class="btn btn-ghost btn-sm" style="margin-top:0.5rem;" href="https://github.com/waterlyapp/waterlyconnect-docs/blob/main/data-submission-api/clients/packages/nodejs-client/README.md" target="_blank" rel="noopener">Open README</a>
           </div>
           <div class="download-card">
             <div class="download-card-title">Client source</div>

--- a/data-submission-api/clients/powershell/index.html
+++ b/data-submission-api/clients/powershell/index.html
@@ -163,7 +163,7 @@ $client.SubmitData($tags)</code></pre>
           <div class="download-card">
             <div class="download-card-title">Package README</div>
             <p class="download-card-desc">Detailed usage, looping examples, cmdlet reference, and configuration notes.</p>
-            <a class="btn btn-ghost btn-sm" style="margin-top:0.5rem;" href="../packages/powershell-client/README.md">Open README</a>
+            <a class="btn btn-ghost btn-sm" style="margin-top:0.5rem;" href="https://github.com/waterlyapp/waterlyconnect-docs/blob/main/data-submission-api/clients/packages/powershell-client/README.md" target="_blank" rel="noopener">Open README</a>
           </div>
           <div class="download-card">
             <div class="download-card-title">Source folder</div>

--- a/data-submission-api/clients/python/index.html
+++ b/data-submission-api/clients/python/index.html
@@ -139,7 +139,7 @@ client.submit_data(tags)</code></pre>
           <div class="download-card">
             <div class="download-card-title">Package README</div>
             <p class="download-card-desc">Detailed usage, class reference, and configuration notes.</p>
-            <a class="btn btn-ghost btn-sm" style="margin-top:0.5rem;" href="../packages/python-client/README.md">Open README</a>
+            <a class="btn btn-ghost btn-sm" style="margin-top:0.5rem;" href="https://github.com/waterlyapp/waterlyconnect-docs/blob/main/data-submission-api/clients/packages/python-client/README.md" target="_blank" rel="noopener">Open README</a>
           </div>
           <div class="download-card">
             <div class="download-card-title">Source folder</div>

--- a/data-submission-api/clients/vt-scada/index.html
+++ b/data-submission-api/clients/vt-scada/index.html
@@ -179,7 +179,7 @@ Site1\\Reservoir\\Level,1,day_at_time,070000|190000,Daily snapshot</code></pre>
           <div class="download-card">
             <div class="download-card-title">Package README</div>
             <p class="download-card-desc">Full setup walkthrough, CSV reference, and troubleshooting notes.</p>
-            <a class="btn btn-ghost btn-sm" style="margin-top:0.5rem;" href="../packages/vt-scada/README.md">Open README</a>
+            <a class="btn btn-ghost btn-sm" style="margin-top:0.5rem;" href="https://github.com/waterlyapp/waterlyconnect-docs/blob/main/data-submission-api/clients/packages/vt-scada/README.md" target="_blank" rel="noopener">Open README</a>
           </div>
           <div class="download-card">
             <div class="download-card-title">Source folder</div>


### PR DESCRIPTION
- On documentation pages, update links to markdown documents to go to github.com, pre-rendered markdown, rather than linking to raw, unparsed markdown docs